### PR TITLE
Use 127.0.0.1 as default

### DIFF
--- a/mongo-example/resources/default.properties
+++ b/mongo-example/resources/default.properties
@@ -5,7 +5,7 @@ console.interval.seconds=1000
 
 default.mongo.port=27017
 
-test-db.mongo.host=localhost
+test-db.mongo.host=127.0.0.1
 test-db.mongo.dbname=teslatest
 test-db.mongo.user=
 test-db.mongo.passwd=


### PR DESCRIPTION
This makes running against a out-of-box mongodb possible, which binds against the IP address (vs. hostname).
